### PR TITLE
Simplify upgradeability storage

### DIFF
--- a/contracts/Factory.sol
+++ b/contracts/Factory.sol
@@ -39,7 +39,7 @@ contract Factory {
   */
   function createProxy(string version) public returns (OwnedUpgradeabilityProxy) {
     OwnedUpgradeabilityProxy proxy = _createProxy();
-    proxy.upgradeTo(version);
+    proxy.upgradeTo(_registry, version);
     proxy.transferProxyOwnership(msg.sender);
     return proxy;
   }
@@ -53,7 +53,7 @@ contract Factory {
   */
   function createProxyAndCall(string version, bytes data) public payable returns (OwnedUpgradeabilityProxy) {
     OwnedUpgradeabilityProxy proxy = _createProxy();
-    proxy.upgradeToAndCall.value(msg.value)(version, data);
+    proxy.upgradeToAndCall.value(msg.value)(_registry, version, data);
     proxy.transferProxyOwnership(msg.sender);
     return proxy;
   }
@@ -63,7 +63,7 @@ contract Factory {
   * @return address of the new proxy created
   */
   function _createProxy() internal returns (OwnedUpgradeabilityProxy) {
-    OwnedUpgradeabilityProxy proxy = new OwnedUpgradeabilityProxy(_registry);
+    OwnedUpgradeabilityProxy proxy = new OwnedUpgradeabilityProxy();
     ProxyCreated(proxy);
     return proxy;
   }

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -32,7 +32,7 @@ contract Registry {
   * @param version to query the implementation of
   * @return address of the implementation registered for the given version
   */
-  function getVersion(string version) public view returns (address) {
+  function getImplementation(string version) public view returns (address) {
     return versions[version];
   }
 }

--- a/contracts/mocks/InitializableMock.sol
+++ b/contracts/mocks/InitializableMock.sol
@@ -8,16 +8,11 @@ import '../Registry.sol';
  * @dev This contract is a mock to test upgradeability functionality
  */
 contract InitializableMock is OwnedUpgradeabilityStorage {
-
   uint256 public x;
 
-  function InitializableMock() 
-    OwnedUpgradeabilityStorage(Registry(0x0))
-    public
-  {}
+  function InitializableMock() public {}
   
   function initialize(uint256 value) public {
     x = value;
   }
-
 }

--- a/contracts/upgradeability/OwnedUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/OwnedUpgradeabilityProxy.sol
@@ -39,7 +39,7 @@ contract OwnedUpgradeabilityProxy is UpgradeabilityProxy, OwnedUpgradeabilitySto
    * @return the address of the proxy owner
    */
   function proxyOwner() public view returns (address) {
-    return upgradeabilityOwner;
+    return _upgradeabilityOwner;
   }
 
   /**

--- a/contracts/upgradeability/OwnedUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/OwnedUpgradeabilityProxy.sol
@@ -16,22 +16,18 @@ contract OwnedUpgradeabilityProxy is UpgradeabilityProxy, OwnedUpgradeabilitySto
   event ProxyOwnershipTransferred(address previousOwner, address newOwner);
 
   /**
-  * @dev the constructor sets the original owner of the contract to the sender account.
-  */
-  function OwnedUpgradeabilityProxy(Registry registry) 
-    UpgradeabilityProxy(registry)
-    OwnedUpgradeabilityStorage(registry)
-    public
-  {
-    setUpgradeabilityOwner(msg.sender);
-  }
-
-  /**
   * @dev Throws if called by any account other than the owner.
   */
   modifier onlyProxyOwner() {
     require(msg.sender == proxyOwner());
     _;
+  }
+
+  /**
+  * @dev the constructor sets the original owner of the contract to the sender account.
+  */
+  function OwnedUpgradeabilityProxy() public {
+    setUpgradeabilityOwner(msg.sender);
   }
 
   /**
@@ -54,21 +50,23 @@ contract OwnedUpgradeabilityProxy is UpgradeabilityProxy, OwnedUpgradeabilitySto
 
   /**
    * @dev Allows the upgradeability owner to upgrade the current version of the proxy.
+   * @param registry representing the registry to query the implementation address of the requested version.
    * @param version representing the version name of the new implementation to be set.
    */
-  function upgradeTo(string version) public onlyProxyOwner {
-    _upgradeTo(version);
+  function upgradeTo(Registry registry, string version) public onlyProxyOwner {
+    _upgradeTo(registry, version);
   }
 
   /**
    * @dev Allows the upgradeability owner to upgrade the current version of the proxy and call the new implementation
    * to initialize whatever is needed through a low level call.
+   * @param registry representing the registry to query the implementation address of the requested version.
    * @param version representing the version name of the new implementation to be set.
    * @param data represents the msg.data to bet sent in the low level call. This parameter may include the function
    * signature of the implementation to be called with the needed payload
    */
-  function upgradeToAndCall(string version, bytes data) payable public onlyProxyOwner {
-    upgradeTo(version);
+  function upgradeToAndCall(Registry registry, string version, bytes data) payable public onlyProxyOwner {
+    upgradeTo(registry, version);
     require(this.call.value(msg.value)(data));
   }
 }

--- a/contracts/upgradeability/OwnedUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/OwnedUpgradeabilityProxy.sol
@@ -50,23 +50,21 @@ contract OwnedUpgradeabilityProxy is UpgradeabilityProxy, OwnedUpgradeabilitySto
 
   /**
    * @dev Allows the upgradeability owner to upgrade the current version of the proxy.
-   * @param registry representing the registry to query the implementation address of the requested version.
-   * @param version representing the version name of the new implementation to be set.
+   * @param implementation representing the address of the new implementation to be set
    */
-  function upgradeTo(Registry registry, string version) public onlyProxyOwner {
-    _upgradeTo(registry, version);
+  function upgradeTo(address implementation) public onlyProxyOwner {
+    _upgradeTo(implementation);
   }
 
   /**
    * @dev Allows the upgradeability owner to upgrade the current version of the proxy and call the new implementation
    * to initialize whatever is needed through a low level call.
-   * @param registry representing the registry to query the implementation address of the requested version.
-   * @param version representing the version name of the new implementation to be set.
+   * @param implementation representing the address of the new implementation to be set
    * @param data represents the msg.data to bet sent in the low level call. This parameter may include the function
    * signature of the implementation to be called with the needed payload
    */
-  function upgradeToAndCall(Registry registry, string version, bytes data) payable public onlyProxyOwner {
-    upgradeTo(registry, version);
+  function upgradeToAndCall(address implementation, bytes data) payable public onlyProxyOwner {
+    upgradeTo(implementation);
     require(this.call.value(msg.value)(data));
   }
 }

--- a/contracts/upgradeability/OwnedUpgradeabilityStorage.sol
+++ b/contracts/upgradeability/OwnedUpgradeabilityStorage.sol
@@ -14,10 +14,7 @@ contract OwnedUpgradeabilityStorage is UpgradeabilityStorage {
   /**
   * @dev Constructor function
   */
-  function OwnedUpgradeabilityStorage(Registry registry) 
-    UpgradeabilityStorage(registry)
-    public
-  {}
+  function OwnedUpgradeabilityStorage() public {}
 
   /**
    * @dev Sets the address of the owner

--- a/contracts/upgradeability/OwnedUpgradeabilityStorage.sol
+++ b/contracts/upgradeability/OwnedUpgradeabilityStorage.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.4.18;
 
 import './UpgradeabilityStorage.sol';
-import '../Registry.sol';
 
 /**
  * @title OwnedUpgradeabilityStorage

--- a/contracts/upgradeability/OwnedUpgradeabilityStorage.sol
+++ b/contracts/upgradeability/OwnedUpgradeabilityStorage.sol
@@ -9,7 +9,7 @@ import '../Registry.sol';
  */
 contract OwnedUpgradeabilityStorage is UpgradeabilityStorage {
   // Owner of the contract
-  address public upgradeabilityOwner;
+  address internal _upgradeabilityOwner;
 
   /**
   * @dev Constructor function
@@ -23,6 +23,6 @@ contract OwnedUpgradeabilityStorage is UpgradeabilityStorage {
    * @dev Sets the address of the owner
    */
   function setUpgradeabilityOwner(address newUpgradeabilityOwner) internal {
-    upgradeabilityOwner = newUpgradeabilityOwner;
+    _upgradeabilityOwner = newUpgradeabilityOwner;
   }
 }

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -11,10 +11,9 @@ import './UpgradeabilityStorage.sol';
 contract UpgradeabilityProxy is Proxy, UpgradeabilityStorage {
   /**
   * @dev This event will be emitted every time the implementation gets upgraded
-  * @param version representing the version name of the upgraded implementation
   * @param implementation representing the address of the upgraded implementation
   */
-  event Upgraded(string version, address indexed implementation);
+  event Upgraded(address indexed implementation);
 
   /**
   * @dev Constructor function
@@ -23,14 +22,13 @@ contract UpgradeabilityProxy is Proxy, UpgradeabilityStorage {
 
   /**
   * @dev Upgrades the implementation address
-  * @param version representing the version name of the new implementation to be set
+  * @param newImplementation representing the address of the new implementation to be set
   */
-  function _upgradeTo(Registry registry, string version) internal {
-    address newImplementation = registry.getImplementation(version);
+  function _upgradeTo(address newImplementation) internal {
     require(newImplementation != address(0));
     require(_implementation != newImplementation);
 
     setImplementation(newImplementation);
-    Upgraded(version, newImplementation);
+    Upgraded(newImplementation);
   }
 }

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -19,22 +19,17 @@ contract UpgradeabilityProxy is Proxy, UpgradeabilityStorage {
   /**
   * @dev Constructor function
   */
-  function UpgradeabilityProxy(Registry registry) 
-    Proxy()
-    UpgradeabilityStorage(registry)
-    public
-  {}
+  function UpgradeabilityProxy() public {}
 
   /**
   * @dev Upgrades the implementation address
   * @param version representing the version name of the new implementation to be set
   */
-  function _upgradeTo(string version) internal {
-    address newImplementation = registry().getVersion(version);
+  function _upgradeTo(Registry registry, string version) internal {
+    address newImplementation = registry.getVersion(version);
     require(newImplementation != address(0));
     require(_implementation != newImplementation);
 
-    _version = version;
     setImplementation(newImplementation);
     Upgraded(version, newImplementation);
   }

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.4.18;
 
-import '../Registry.sol';
 import './Proxy.sol';
 import './UpgradeabilityStorage.sol';
 

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -30,12 +30,12 @@ contract UpgradeabilityProxy is Proxy, UpgradeabilityStorage {
   * @param version representing the version name of the new implementation to be set
   */
   function _upgradeTo(string version) internal {
-    address implementation = registry().getVersion(version);
-    require(implementation != address(0));
-    require(_implementation != implementation);
+    address newImplementation = registry().getVersion(version);
+    require(newImplementation != address(0));
+    require(_implementation != newImplementation);
 
     _version = version;
-    _implementation = implementation;
-    Upgraded(version, implementation);
+    setImplementation(newImplementation);
+    Upgraded(version, newImplementation);
   }
 }

--- a/contracts/upgradeability/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/UpgradeabilityProxy.sol
@@ -26,7 +26,7 @@ contract UpgradeabilityProxy is Proxy, UpgradeabilityStorage {
   * @param version representing the version name of the new implementation to be set
   */
   function _upgradeTo(Registry registry, string version) internal {
-    address newImplementation = registry.getVersion(version);
+    address newImplementation = registry.getImplementation(version);
     require(newImplementation != address(0));
     require(_implementation != newImplementation);
 

--- a/contracts/upgradeability/UpgradeabilityProxyFactory.sol
+++ b/contracts/upgradeability/UpgradeabilityProxyFactory.sol
@@ -1,20 +1,20 @@
 pragma solidity ^0.4.18;
 
-import './upgradeability/OwnedUpgradeabilityProxy.sol';
-import './Registry.sol';
+import '../Registry.sol';
+import './OwnedUpgradeabilityProxy.sol';
 
 /**
- * @title Factory
+ * @title UpgradeabilityProxyFactory
  * @dev This contracts provides required functionality to create upgradeability proxies
  */
-contract Factory {
+contract UpgradeabilityProxyFactory {
   // Versions registry
   Registry internal _registry;
 
   /**
   * @dev Constructor function
   */
-  function Factory(Registry registry) public {
+  function UpgradeabilityProxyFactory(Registry registry) public {
     _registry = registry;
   }
 

--- a/contracts/upgradeability/UpgradeabilityProxyFactory.sol
+++ b/contracts/upgradeability/UpgradeabilityProxyFactory.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.4.18;
 
-import '../Registry.sol';
 import './OwnedUpgradeabilityProxy.sol';
 
 /**
@@ -8,23 +7,10 @@ import './OwnedUpgradeabilityProxy.sol';
  * @dev This contracts provides required functionality to create upgradeability proxies
  */
 contract UpgradeabilityProxyFactory {
-  // Versions registry
-  Registry internal _registry;
-
   /**
   * @dev Constructor function
   */
-  function UpgradeabilityProxyFactory(Registry registry) public {
-    _registry = registry;
-  }
-
-  /**
-  * @dev Tells the address of the registry
-  * @return address of the registry
-  */
-  function registry() public view returns (Registry) {
-    return _registry;
-  }
+  function UpgradeabilityProxyFactory() public {}
 
   /**
   * @dev This event will be emitted every time a new proxy is created
@@ -34,27 +20,29 @@ contract UpgradeabilityProxyFactory {
 
   /**
   * @dev Creates an upgradeable proxy upgraded to an initial version
-  * @param version representing the first version to be set for the proxy
+  * @param owner representing the owner of the proxy to be set
+  * @param implementation representing the address of the initial implementation to be set
   * @return address of the new proxy created
   */
-  function createProxy(string version) public returns (OwnedUpgradeabilityProxy) {
+  function createProxy(address owner, address implementation) public returns (OwnedUpgradeabilityProxy) {
     OwnedUpgradeabilityProxy proxy = _createProxy();
-    proxy.upgradeTo(_registry, version);
-    proxy.transferProxyOwnership(msg.sender);
+    proxy.upgradeTo(implementation);
+    proxy.transferProxyOwnership(owner);
     return proxy;
   }
 
   /**
   * @dev Creates an upgradeable proxy upgraded to an initial version and call the new implementation
-  * @param version representing the first version to be set for the proxy
+  * @param owner representing the owner of the proxy to be set
+  * @param implementation representing the address of the initial implementation to be set
   * @param data represents the msg.data to bet sent in the low level call. This parameter may include the function
   * signature of the implementation to be called with the needed payload
   * @return address of the new proxy created
   */
-  function createProxyAndCall(string version, bytes data) public payable returns (OwnedUpgradeabilityProxy) {
+  function createProxyAndCall(address owner, address implementation, bytes data) public payable returns (OwnedUpgradeabilityProxy) {
     OwnedUpgradeabilityProxy proxy = _createProxy();
-    proxy.upgradeToAndCall.value(msg.value)(_registry, version, data);
-    proxy.transferProxyOwnership(msg.sender);
+    proxy.upgradeToAndCall.value(msg.value)(implementation, data);
+    proxy.transferProxyOwnership(owner);
     return proxy;
   }
 

--- a/contracts/upgradeability/UpgradeabilityStorage.sol
+++ b/contracts/upgradeability/UpgradeabilityStorage.sol
@@ -24,6 +24,14 @@ contract UpgradeabilityStorage {
   }
 
   /**
+  * @dev Tells the address of registry
+  * @return address of the registry
+  */
+  function registry() public view returns (Registry) {
+    return _registry;
+  }
+
+  /**
   * @dev Tells the version name of the current implementation
   * @return string representing the name of the current version
   */
@@ -40,10 +48,9 @@ contract UpgradeabilityStorage {
   }
 
   /**
-  * @dev Tells the address of registry
-  * @return address of the registry
-  */
-  function registry() public view returns (Registry) {
-    return _registry;
+   * @dev Sets the address of the current implementation
+   */
+  function setImplementation(address newImplementation) internal {
+    _implementation = newImplementation;
   }
 }

--- a/contracts/upgradeability/UpgradeabilityStorage.sol
+++ b/contracts/upgradeability/UpgradeabilityStorage.sol
@@ -7,37 +7,13 @@ import '../Registry.sol';
  * @dev This contract holds all the necessary state variables to support the upgrade functionality
  */
 contract UpgradeabilityStorage {
-  // Versions registry
-  Registry private _registry;
-
-  // Version name of the current implementation
-  string internal _version;
-
   // Address of the current implementation
   address internal _implementation;
 
   /**
   * @dev Constructor function
   */
-  function UpgradeabilityStorage(Registry registry) public {
-    _registry = registry;
-  }
-
-  /**
-  * @dev Tells the address of registry
-  * @return address of the registry
-  */
-  function registry() public view returns (Registry) {
-    return _registry;
-  }
-
-  /**
-  * @dev Tells the version name of the current implementation
-  * @return string representing the name of the current version
-  */
-  function version() public view returns (string) {
-    return _version;
-  }
+  function UpgradeabilityStorage() public {}
 
   /**
   * @dev Tells the address of the current implementation

--- a/contracts/upgradeability/UpgradeabilityStorage.sol
+++ b/contracts/upgradeability/UpgradeabilityStorage.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.4.18;
 
-import '../Registry.sol';
-
 /**
  * @title UpgradeabilityStorage
  * @dev This contract holds all the necessary state variables to support the upgrade functionality

--- a/test/Registry.test.js
+++ b/test/Registry.test.js
@@ -17,7 +17,7 @@ contract('Registry', ([_, owner, implementation_v0, implementation_v1]) => {
         it('registers the given version', async function () {
           await this.registry.addVersion(version, implementation)
 
-          const registeredImplementation = await this.registry.getVersion(version)
+          const registeredImplementation = await this.registry.getImplementation(version)
           assert.equal(registeredImplementation, implementation)
         })
 
@@ -37,10 +37,10 @@ contract('Registry', ([_, owner, implementation_v0, implementation_v1]) => {
           await this.registry.addVersion(version, implementation)
           await this.registry.addVersion(anotherVersion, anotherImplementation)
 
-          const registeredImplementation = await this.registry.getVersion(version)
+          const registeredImplementation = await this.registry.getImplementation(version)
           assert.equal(registeredImplementation, implementation)
 
-          const newRegisteredImplementation = await this.registry.getVersion(anotherVersion)
+          const newRegisteredImplementation = await this.registry.getImplementation(anotherVersion)
           assert.equal(newRegisteredImplementation, anotherImplementation)
         })
       })
@@ -74,10 +74,10 @@ contract('Registry', ([_, owner, implementation_v0, implementation_v1]) => {
 
           await this.registry.addVersion(anotherVersion, anotherImplementation)
 
-          const registeredImplementation = await this.registry.getVersion(version)
+          const registeredImplementation = await this.registry.getImplementation(version)
           assert.equal(registeredImplementation, implementation)
 
-          const newRegisteredImplementation = await this.registry.getVersion(anotherVersion)
+          const newRegisteredImplementation = await this.registry.getImplementation(anotherVersion)
           assert.equal(newRegisteredImplementation, anotherImplementation)
         })
       })

--- a/test/helpers/encodeCall.js
+++ b/test/helpers/encodeCall.js
@@ -1,0 +1,9 @@
+const abi = require('ethereumjs-abi')
+
+function encodeCall(name, arguments, values) {
+  const methodId = abi.methodID(name, arguments).toString('hex');
+  const params = abi.rawEncode(arguments, values).toString('hex');
+  return '0x' + methodId + params;
+}
+
+module.exports = encodeCall;

--- a/test/upgradeability/OwnedUpgradeabilityProxy.js
+++ b/test/upgradeability/OwnedUpgradeabilityProxy.js
@@ -25,14 +25,6 @@ contract('OwnedUpgradeabilityProxy', ([owner, anotherAccount, implementation_v0,
     })
   })
 
-  describe('version', function () {
-    it('returns the current version', async function () {
-      const version = await this.proxy.version()
-
-      assert.equal(version, '0')
-    })
-  })
-
   describe('implementation', function () {
     it('returns the current implementation address', async function () {
       const implementation = await this.proxy.implementation()
@@ -42,18 +34,15 @@ contract('OwnedUpgradeabilityProxy', ([owner, anotherAccount, implementation_v0,
   })
 
   describe('upgradeTo', function () {
-    it('returns the new version and implementation', async function () {
-      await this.proxy.upgradeTo('1')
+    it('returns the new implementation', async function () {
+      await this.proxy.upgradeTo(this.registry.address, '1')
 
-      const version = await this.proxy.version();
       const implementation = await this.proxy.implementation()
-
-      assert.equal(version, '1')
       assert.equal(implementation, implementation_v1)
     })
 
     it('emits an event', async function () {
-      const { logs } = await this.proxy.upgradeTo('1')
+      const { logs } = await this.proxy.upgradeTo(this.registry.address, '1')
 
       assert.equal(logs.length, 1)
       assert.equal(logs[0].event, 'Upgraded')

--- a/test/upgradeability/OwnedUpgradeabilityProxy.js
+++ b/test/upgradeability/OwnedUpgradeabilityProxy.js
@@ -2,13 +2,13 @@
 
 const assertRevert = require('../helpers/assertRevert')
 const Registry = artifacts.require('Registry')
-const Factory = artifacts.require('Factory')
 const OwnedUpgradeabilityProxy = artifacts.require('OwnedUpgradeabilityProxy')
+const UpgradeabilityProxyFactory = artifacts.require('UpgradeabilityProxyFactory')
 
 contract('OwnedUpgradeabilityProxy', ([owner, anotherAccount, implementation_v0, implementation_v1]) => {
   beforeEach(async function () {
     this.registry = await Registry.new()
-    this.factory = await Factory.new(this.registry.address)
+    this.factory = await UpgradeabilityProxyFactory.new(this.registry.address)
     await this.registry.addVersion('0', implementation_v0)
     await this.registry.addVersion('1', implementation_v1)
 

--- a/test/upgradeability/OwnedUpgradeabilityProxy.js
+++ b/test/upgradeability/OwnedUpgradeabilityProxy.js
@@ -1,24 +1,19 @@
 'use strict'
 
 const assertRevert = require('../helpers/assertRevert')
-const Registry = artifacts.require('Registry')
 const OwnedUpgradeabilityProxy = artifacts.require('OwnedUpgradeabilityProxy')
 const UpgradeabilityProxyFactory = artifacts.require('UpgradeabilityProxyFactory')
 
-contract('OwnedUpgradeabilityProxy', ([owner, anotherAccount, implementation_v0, implementation_v1]) => {
+contract('OwnedUpgradeabilityProxy', ([_, owner, anotherAccount, implementation_v0, implementation_v1]) => {
   beforeEach(async function () {
-    this.registry = await Registry.new()
-    this.factory = await UpgradeabilityProxyFactory.new(this.registry.address)
-    await this.registry.addVersion('0', implementation_v0)
-    await this.registry.addVersion('1', implementation_v1)
-
-    const { logs } = await this.factory.createProxy('0', { from: owner })
+    this.factory = await UpgradeabilityProxyFactory.new()
+    const { logs } = await this.factory.createProxy(owner, implementation_v0)
     const proxyAddress = logs.find(l => l.event === 'ProxyCreated').args.proxy
     this.proxy = await OwnedUpgradeabilityProxy.at(proxyAddress)
   })
 
   describe('owner', function () {
-    it('sets the sender as the owner', async function () {
+    it('transfers the ownership to the requested owner', async function () {
       const proxyOwner = await this.proxy.proxyOwner()
 
       assert.equal(proxyOwner, owner)
@@ -34,20 +29,32 @@ contract('OwnedUpgradeabilityProxy', ([owner, anotherAccount, implementation_v0,
   })
 
   describe('upgradeTo', function () {
-    it('returns the new implementation', async function () {
-      await this.proxy.upgradeTo(this.registry.address, '1')
 
-      const implementation = await this.proxy.implementation()
-      assert.equal(implementation, implementation_v1)
+    describe('when the sender is the owner', function () {
+      const from = owner
+
+      it('returns the new implementation', async function () {
+        await this.proxy.upgradeTo(implementation_v1, { from })
+
+        const implementation = await this.proxy.implementation()
+        assert.equal(implementation, implementation_v1)
+      })
+
+      it('emits an event', async function () {
+        const { logs } = await this.proxy.upgradeTo(implementation_v1, { from })
+
+        assert.equal(logs.length, 1)
+        assert.equal(logs[0].event, 'Upgraded')
+        assert.equal(logs[0].args.implementation, implementation_v1)
+      })
     })
 
-    it('emits an event', async function () {
-      const { logs } = await this.proxy.upgradeTo(this.registry.address, '1')
+    describe('when the sender is not the owner', function () {
+      const from = anotherAccount
 
-      assert.equal(logs.length, 1)
-      assert.equal(logs[0].event, 'Upgraded')
-      assert.equal(logs[0].args.version, '1')
-      assert.equal(logs[0].args.implementation, implementation_v1)
+      it('reverts', async function () {
+        await assertRevert(this.proxy.upgradeTo(implementation_v1, { from }))
+      })
     })
   })
 

--- a/test/upgradeability/UpgradeabilityProxyFactory.test.js
+++ b/test/upgradeability/UpgradeabilityProxyFactory.test.js
@@ -1,16 +1,16 @@
 'use strict';
 
 const abi = require('ethereumjs-abi')
-const assertRevert = require('./helpers/assertRevert')
-const Factory = artifacts.require('Factory')
+const assertRevert = require('../helpers/assertRevert')
 const Registry = artifacts.require('Registry')
 const InitializableMock = artifacts.require('InitializableMock')
 const OwnedUpgradeabilityProxy = artifacts.require('OwnedUpgradeabilityProxy')
+const UpgradeabilityProxyFactory = artifacts.require('UpgradeabilityProxyFactory')
 
-contract('Factory', ([_, owner, implementation_v0]) => {
+contract('UpgradeabilityProxyFactory', ([_, owner, implementation_v0]) => {
   beforeEach(async function () {
     this.registry = await Registry.new()
-    this.factory = await Factory.new(this.registry.address)
+    this.factory = await UpgradeabilityProxyFactory.new(this.registry.address)
   })
 
   it('sets the correct registry', async function () {


### PR DESCRIPTION
This is an alternative and possible improvement we've been discussing with @spalladino 

We arrived to this alternative after what we got developing the first proposal of the kernel (see https://github.com/zeppelinos/labs/pull/51). Given some part of the code involves an upgradeability mechanism, we thought about reusing the mechanism of `zos-core`. The only thing different was the `Registry` contract. However, we realised we could reduce the upgradeability mechanism storage as much as possible, getting it to work just with the upgradeability owner and the pointed implementation address. 

I would like for us to discuss this idea a bit more, and see pros and cons together. The biggest con I see is that the `Registry` contract proposed by `zos-core` is a lonely contract that is never used from any of the upgradeability contracts, and it will depend on each project whether to use it or not. OTOH, the biggest pro would be to use `zos-core` from the kernel, although we are still working the kernel model. In addition, we could think of some alternatives to reuse `zos-core`, e.g. redefining the `Registry` interface to match what we need in the kernel too. 

Let's discuss about it @frangio @spalladino @fiiiu @ajsantander 