### PR TITLE
Improve proxy's fallback gas cost

### DIFF
--- a/contracts/upgradeability/Proxy.sol
+++ b/contracts/upgradeability/Proxy.sol
@@ -18,13 +18,12 @@ contract Proxy {
   function () payable public {
     address _impl = implementation();
     require(_impl != address(0));
-    bytes memory data = msg.data;
 
     assembly {
-      let result := delegatecall(gas, _impl, add(data, 0x20), mload(data), 0, 0)
-      let size := returndatasize
-
       let ptr := mload(0x40)
+      calldatacopy(ptr, 0, calldatasize)
+      let result := delegatecall(gas, _impl, ptr, calldatasize, 0, 0)
+      let size := returndatasize
       returndatacopy(ptr, 0, size)
 
       switch result


### PR DESCRIPTION
I measured the current proxy contract and a possible alternative in remix with the optimizer enabled and the compiler version `0.4.21+commit.dfe3193c`. I got the following results:

<img width="722" alt="screen shot 2018-04-02 at 14 01 30" src="https://user-images.githubusercontent.com/6967192/38205855-85292150-367e-11e8-9334-ae4dda913fb4.png">

As you can see the call using `Proxy1` costs 210 less gas than the one with `Proxy2`, where `Proxy2` follows the current implementation and `Proxy1` is an alternative. Here are the contracts I used:

```
contract Proxy1 {
  address public implementation;
  
  function setImplementation(address newImplementation) public {
      implementation = newImplementation;
  }

  function () payable public {
    address _impl = implementation;
    assembly {
      let ptr := mload(0x40)
      calldatacopy(ptr, 0, calldatasize)
      let result := delegatecall(gas, _impl, ptr, calldatasize, 0, 0)
      let size := returndatasize
      returndatacopy(ptr, 0, size)

      switch result
      case 0 { revert(ptr, size) }
      default { return(ptr, size) }
    }
  }
}

contract Proxy2 {
   address public implementation;
  
  function setImplementation(address newImplementation) public {
      implementation = newImplementation;
  }

  function () payable public {
    address _impl = implementation;
    bytes memory data = msg.data;

    assembly {
      let result := delegatecall(gas, _impl, add(data, 0x20), mload(data), 0, 0)
      let size := returndatasize
      let ptr := mload(0x40)
      returndatacopy(ptr, 0, size)

      switch result
      case 0 { revert(ptr, size) }
      default { return(ptr, size) }
    }
  }   
}

contract Test {
    function test(uint256 n) public pure returns (uint256) {
        return n * 2;
    }
}
```

Please @spalladino and @frangio review, would love to hear your thoughts. Thx