### PR TITLE
Restore ownership contracts

### DIFF
--- a/contracts/ownership/Ownable.sol
+++ b/contracts/ownership/Ownable.sol
@@ -1,0 +1,41 @@
+pragma solidity ^0.4.18;
+
+import './OwnableStorage.sol';
+
+/**
+ * @title Ownable
+ * @dev This contract has the owner address providing basic authorization control
+ */
+contract Ownable is OwnableStorage {
+  /**
+  * @dev Event to show ownership has been transferred
+  * @param previousOwner representing the address of the previous owner
+  * @param newOwner representing the address of the new owner
+  */
+  event OwnershipTransferred(address previousOwner, address newOwner);
+
+  /**
+  * @dev The constructor sets the original owner of the contract to the sender account.
+  */
+  function Ownable() public {
+    setOwner(msg.sender);
+  }
+
+  /**
+  * @dev Throws if called by any account other than the owner.
+  */
+  modifier onlyOwner() {
+    require(msg.sender == owner());
+    _;
+  }
+
+  /**
+   * @dev Allows the current owner to transfer control of the contract to a newOwner.
+   * @param newOwner The address to transfer ownership to.
+   */
+  function transferOwnership(address newOwner) public onlyOwner {
+    require(newOwner != address(0));
+    emit OwnershipTransferred(owner(), newOwner);
+    setOwner(newOwner);
+  }
+}

--- a/contracts/ownership/OwnableStorage.sol
+++ b/contracts/ownership/OwnableStorage.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.4.18;
+
+/**
+ * @title OwnableStorage
+ * @dev This contract keeps track of the owner's address
+ */
+contract OwnableStorage {
+  // Owner of the contract
+  address private _owner;
+
+  /**
+   * @dev Tells the address of the owner
+   * @return the address of the owner
+   */
+  function owner() public view returns (address) {
+    return _owner;
+  }
+
+  /**
+   * @dev Sets a new owner address
+   */
+  function setOwner(address newOwner) internal {
+    _owner = newOwner;
+  }
+}


### PR DESCRIPTION
**TL;DR**
A few days ago, we removed Ownable.sol and OwnableStorage.sol because they weren't being used by any of the other contracts within core directly. However, these contracts are needed externally by projects that use core, and the classic OpenZeppelin Ownable cannot replace it. 

**Explanation**
OZ's Ownable can only transfer ownership via `transferOwnership(address newOwner) public onlyOwner`. That is, it can only transfer ownership when there is an external call with `msg.sender == tx.origin`.

With core, ProjectController's `createAndCall()` might call an initialize method where the ownership is transferred from the deployer of an implementation to `msg.sender`. That is, `msg.sender != tx.origin`. At the time of the initializer execution, `msg.sender` is the controller.

To resolve this, the contracts being restored have the ability to transfer ownership via an `internal` `setOwner` call that has no requirements about the sender. This gives the contract itself the faculty to assign ownership, which is a feature missing from OZ's Ownable, and essential for contracts that need the proxy to assign ownership in an "on-chain constructor": the `initialize` function.